### PR TITLE
#0040 勤務場所、勤怠実績一覧の時間、ユーザー名、メール、電話番号を修正

### DIFF
--- a/attendance-system/db/schema.sql
+++ b/attendance-system/db/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE users (
     display_name            VARCHAR(100)    NOT NULL,                 -- 画面表示用の名前
     password_hash           TEXT            NOT NULL,                 -- パスワード（ハッシュ値）
     email                   VARCHAR(255)    UNIQUE,                   -- メールアドレス（一意・NULL許可）
-    phone                   VARCHAR(20),                              -- 電話番号（NULL許可）
+    phone                   VARCHAR(20)     UNIQUE,                   -- 電話番号（NULL許可・一意）
     role                    SMALLINT        NOT NULL DEFAULT 2        -- 権限フラグ 1=admin, 2=user
         CHECK (role IN (1, 2)),
     department_id           INTEGER         NOT NULL                  -- 所属部署ID（departments.id）

--- a/attendance-system/src/main/java/com/example/attendance/controller/AttendanceController.java
+++ b/attendance-system/src/main/java/com/example/attendance/controller/AttendanceController.java
@@ -198,12 +198,43 @@ public class AttendanceController {
 
     @PostMapping("/work-location")
     public String updateWorkLocation(
-            @RequestParam(name = "workLocationId", required = false) Integer workLocationId,
+            @RequestParam(name = "workLocationId", required = false) String workLocationIdValue,
             HttpSession session,
             RedirectAttributes redirectAttributes,
             Locale locale) {
 
         Integer userId = (Integer) session.getAttribute("userId");
+        Integer workLocationId = null;
+
+        // 1) 入力がある場合だけチェックして Integer に変換
+        if (workLocationIdValue != null && !workLocationIdValue.isBlank()) {
+
+            String trimmed = workLocationIdValue.trim(); // ★空白対策
+
+            // ★数字以外を弾く（aaa / 1,2 / -1 など）
+            if (!trimmed.matches("\\d+")) {
+                String msg = messageSource.getMessage("validation.workLocation.invalid", null, locale);
+                redirectAttributes.addFlashAttribute("flashError", msg);
+                return "redirect:/attendance/work-location";
+            }
+
+            try {
+                workLocationId = Integer.valueOf(trimmed);
+
+                // ★0以下は不正
+                if (workLocationId <= 0) {
+                    String msg = messageSource.getMessage("validation.workLocation.invalid", null, locale);
+                    redirectAttributes.addFlashAttribute("flashError", msg);
+                    return "redirect:/attendance/work-location";
+                }
+
+            } catch (NumberFormatException e) {
+                // 桁が大きすぎる等のケース
+                String msg = messageSource.getMessage("validation.workLocation.invalid", null, locale);
+                redirectAttributes.addFlashAttribute("flashError", msg);
+                return "redirect:/attendance/work-location";
+            }
+        }
 
         try {
             userSettingService.updateWorkLocation(userId, workLocationId);

--- a/attendance-system/src/main/java/com/example/attendance/repository/UserRepository.java
+++ b/attendance-system/src/main/java/com/example/attendance/repository/UserRepository.java
@@ -22,7 +22,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
       SELECT user
       FROM User user
       WHERE user.username = :username
-        AND user.deletedAt IS NULL
       """)
   Optional<User> findByUsername(@Param("username") String username);
 
@@ -47,7 +46,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
       SELECT u
       FROM User u
       WHERE u.email = :email
-        AND u.deletedAt IS NULL
       """)
   Optional<User> findByEmail(@Param("email") String email);
 
@@ -62,7 +60,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
       SELECT u
       FROM User u
       WHERE u.phone = :phone
-        AND u.deletedAt IS NULL
       """)
   Optional<User> findByPhone(@Param("phone") String phone);
 

--- a/attendance-system/src/main/java/com/example/attendance/service/AdminUserService.java
+++ b/attendance-system/src/main/java/com/example/attendance/service/AdminUserService.java
@@ -129,6 +129,10 @@ public class AdminUserService {
             // 権限必須
             throw new BusinessException("validation.role.required");
         }
+        // 権限の値チェック
+        if (!isValidRole(role)) {
+            throw new BusinessException("validation.role.invalid");
+        }
 
         // 部署あたりの人数上限チェック
         if (userRepository.countActiveByDepartmentId(departmentId) >= MAX_USERS_PER_DEPARTMENT) {
@@ -296,6 +300,10 @@ public class AdminUserService {
         // 1-3) 権限必須
         if (role == null) {
             throw new BusinessException("validation.role.required");
+        }
+        // 権限の値チェック
+        if (!isValidRole(role)) {
+            throw new BusinessException("validation.role.invalid");
         }
 
         // ===== 2) 形式チェック =====
@@ -523,6 +531,13 @@ public class AdminUserService {
         if (value.length() > max) {
             throw new BusinessException(messageKey);
         }
+    }
+
+    /**
+     * 権限の値チェック
+     */
+    private boolean isValidRole(Integer role) {
+        return role != null && (role == 1 || role == 2);
     }
 
     /**

--- a/attendance-system/src/main/resources/templates/work_report.html
+++ b/attendance-system/src/main/resources/templates/work_report.html
@@ -50,15 +50,27 @@
                                 </td>
 
                                 <!-- 出勤時刻（未設定なら「-」） -->
-                                <td
-                                    th:text="${record.clockIn != null ? #temporals.format(record.clockIn, 'HH:mm') : '-'}">
+                                <td th:text="${record.clockIn != null
+                                                ? #temporals.format(
+                                                    record.clockIn.withOffsetSameInstant(
+                                                        T(java.time.ZoneOffset).ofHours(9)
+                                                    ),
+                                                    'HH:mm'
+                                                )
+                                            : '-'}">
                                     8:00
                                 </td>
 
 
                                 <!-- 退勤時刻（未設定なら「-」） -->
-                                <td
-                                    th:text="${record.clockOut != null ? #temporals.format(record.clockOut, 'HH:mm') : '-'}">
+                                <td th:text="${record.clockOut != null
+                                                ? #temporals.format(
+                                                    record.clockOut.withOffsetSameInstant(
+                                                        T(java.time.ZoneOffset).ofHours(9)
+                                                    ),
+                                                    'HH:mm'
+                                                )
+                                            : '-'}">
                                     22:00
                                 </td>
 

--- a/attendance-system/src/test/java/com/example/attendance/service/UserSettingServiceContactTest.java
+++ b/attendance-system/src/test/java/com/example/attendance/service/UserSettingServiceContactTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
勤怠場所に文字が入力された時不正な値扱いにする
権限に1,2以外が入力された時不正な値扱いにする
勤怠実績一覧の時間のズレ修正
ユーザー名、メール、電話番号が論理削除されたユーザーと同じ時エラーメッセージが出る様に修正